### PR TITLE
Set NPM scope for GitHub package publishing

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           node-version: 20
           registry-url: https://npm.pkg.github.com/
+          scope: '@elrayes'
       - run: npm ci
       - run: npm publish
         env:


### PR DESCRIPTION
Added the `scope` field with `@elrayes` in the release workflow to ensure packages are published under the correct namespace. This change aligns with the repository's package management configuration.